### PR TITLE
Add bcl2fastq2.20 output to report and test with MultiQC release v1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+resources/home/dnanexus/Miniconda2-latest-Linux-x86_64.sh
+resources/home/dnanexus/auth_key

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dnanexus_multiqc 
-*moka-guys github release : v.1.4*
+
+*moka-guys github release : v1.3*
+
 *ewels/MultiQC v1.3*
 
 ## What does this app do?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# dnanexus_multiqc v 1.2
+# dnanexus_multiqc v 1.3
 
 ## What does this app do?
-This app runs MultiQC to generate run wide QC using the outputs from Picard CalculateHsMetrics, MarkDuplicates and CollectMultipleMetrics and FastQC
+This app runs MultiQC to generate run wide QC using the outputs from Picard CalculateHsMetrics, MarkDuplicates and CollectMultipleMetrics and FastQC and bcl2fastq2
 
 This app uses a release of MultiQC  from https://github.com/moka-guys/MultiQC
 
@@ -17,6 +17,8 @@ This folder must contain one of each of the following files:
 * hsmetrics.tsv
 * base_distribution_by_cycle_metrics
 * output.metrics
+Additionally the project folder must have a Stats.json file in Data/Intensities/BaseCalls/Stats in order to
+include stats from bcl2fastq2 in the summary.
 
 ## What does this app output?
 1. A HTML QC report which should be uploaded to stickie.be

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# dnanexus_multiqc v 1.3
+# dnanexus_multiqc 
+*moka-guys github release : v.1.4*
+*ewels/MultiQC v1.3*
 
 ## What does this app do?
 This app runs MultiQC to generate run wide QC using the outputs from Picard CalculateHsMetrics, MarkDuplicates and CollectMultipleMetrics and FastQC and bcl2fastq2
 
-This app uses a release of MultiQC  from https://github.com/moka-guys/MultiQC
+This app uses a release of MultiQC from https://github.com/moka-guys/MultiQC
 
 ## What are typical use cases for this app?
 This app should be performed after each run. It can be run automagically using the --depends-on flag or manually.

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,13 +1,13 @@
 {
   "name": "multiqc",
   "title": "MultiQC",
-  "summary": "v1.2 - Generates a run-wide QC report on various QC data files",
+  "summary": "v1.3 - Generates a run-wide QC report on various QC data files",
   "tags": [
     "Read QC",
     "Statistics"
   ],
   "properties": {
-    "github release": "v1.2"
+    "github release": "v1.3"
   },
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,13 +1,13 @@
 {
   "name": "multiqc",
   "title": "MultiQC",
-  "summary": "v1.3 - Generates a run-wide QC report on various QC data files",
+  "summary": "v1.4 - Generates a run-wide QC report on various QC data files",
   "tags": [
     "Read QC",
     "Statistics"
   ],
   "properties": {
-    "github release": "v1.3"
+    "github release": "v1.4"
   },
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,13 +1,13 @@
 {
   "name": "multiqc",
   "title": "MultiQC",
-  "summary": "v1.4 - Generates a run-wide QC report on various QC data files",
+  "summary": "v1.3 - Generates a run-wide QC report on various QC data files",
   "tags": [
     "Read QC",
     "Statistics"
   ],
   "properties": {
-    "github release": "v1.4"
+    "github release": "v1.3"
   },
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/src/code.sh
+++ b/src/code.sh
@@ -22,9 +22,10 @@ dx download $project_for_multiqc:QC/*output.metrics --auth $API_KEY
 dx download $project_for_multiqc:QC/*stats-fastqc.txt --auth $API_KEY
 
 # Find unique File ID for stats.json file in project
-stats_json = $(dx find data --path $project_for_multiqc fastq_MultiQC: --name "Stats.json" | cut -f8 -d ' ' | tr -d '()')
+stats_json=$(dx find data --path ${project_for_multiqc}: --name "Stats.json" | cut -f8 -d ' ' | tr -d '()')
 # If stats.json file is present download
-if[[ $stats_json =~ ^"file" ]]; then #
+if [[ $stats_json =~ ^"file" ]]
+then 
 dx download $stats_json --auth $API_KEY
 else
 echo "No Stats.json file found in /Data/Intensities/BaseCalls/Stats/, bcl2fast2 stats not included in summary"
@@ -72,4 +73,3 @@ multiqc /home/dnanexus/to_test/ -n /home/dnanexus/out/multiqc/QC/multiqc/$NGS_da
 
 # Upload results
 dx-upload-all-outputs
-

--- a/src/code.sh
+++ b/src/code.sh
@@ -21,6 +21,15 @@ dx download $project_for_multiqc:QC/*insert_size_metrics --auth $API_KEY
 dx download $project_for_multiqc:QC/*output.metrics --auth $API_KEY
 dx download $project_for_multiqc:QC/*stats-fastqc.txt --auth $API_KEY
 
+# Find unique File ID for stats.json file in project
+stats_json = $(dx find data --path $project_for_multiqc fastq_MultiQC: --name "Stats.json" | cut -f8 -d ' ' | tr -d '()')
+# If stats.json file is present download
+if[[ $stats_json =~ ^"file" ]]; then #
+dx download $stats_json --auth $API_KEY
+else
+echo "No Stats.json file found in /Data/Intensities/BaseCalls/Stats/, bcl2fast2 stats not included in summary"
+fi
+
 # cd back to home
 cd ..
 
@@ -58,8 +67,9 @@ mkdir -p /home/dnanexus/out/multiqc/QC/multiqc
 
 # Run multiQC
 # # command is : multiqc <dir containing files> -m module1 -m module2 -n <path/to/output>
-multiqc /home/dnanexus/to_test/ -m fastqc -m picard -n /home/dnanexus/out/multiqc/QC/multiqc/$NGS_date-multiqc.html -c /home/dnanexus/to_test/multiqc_config.yaml
+multiqc /home/dnanexus/to_test/ -n /home/dnanexus/out/multiqc/QC/multiqc/$NGS_date-multiqc.html -c /home/dnanexus/to_test/multiqc_config.yaml
 
 
 # Upload results
 dx-upload-all-outputs
+

--- a/src/code.sh
+++ b/src/code.sh
@@ -21,14 +21,17 @@ dx download $project_for_multiqc:QC/*insert_size_metrics --auth $API_KEY
 dx download $project_for_multiqc:QC/*output.metrics --auth $API_KEY
 dx download $project_for_multiqc:QC/*stats-fastqc.txt --auth $API_KEY
 
-# Find unique File ID for stats.json file in project
+# Find unique File ID for Stats.json file in project.
+# Files in the QC folder are placed there by third-party QC programs before being downloaded to the worker
+# Stats.json is the exception. It is uploaded with the runfolder at Data/Intesities/BaseCalls/Stats/.
+# This search makes sure it is found in the project/runfolder regardless of project name.
 stats_json=$(dx find data --path ${project_for_multiqc}: --name "Stats.json" | cut -f8 -d ' ' | tr -d '()')
 # If stats.json file is present download
 if [[ $stats_json =~ ^"file" ]]
 then 
 dx download $stats_json --auth $API_KEY
 else
-echo "No Stats.json file found in /Data/Intensities/BaseCalls/Stats/, bcl2fast2 stats not included in summary"
+echo "No Stats.json file found in /Data/Intensities/BaseCalls/Stats/, bcl2fastq2 stats not included in summary"
 fi
 
 # cd back to home
@@ -52,6 +55,10 @@ for f in ~/to_test/* ; do
 done
 echo $WES
 
+# Test MultiQC from development branch of moka-guys fork
+# git clone -b dev_v1.3 https://github.com/moka-guys/MultiQC.git
+
+# Clone and install MultiQC from master branch of moka-guys fork
 git clone https://github.com/moka-guys/MultiQC.git
 cd MultiQC
 python setup.py install


### PR DESCRIPTION
- Adds Stats.json file from bcl2fastq v2.20 (uploaded with runfolder) to the multiqc output
- Runs with MultiQC release v1.3 with no errors or changes to stats reported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_multiqc/15)
<!-- Reviewable:end -->
