### PR TITLE
V1.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 resources/home/dnanexus/auth_key
+resources/usr/bin/multiqc.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9
+
+LABEL author="David Brawand" \
+      description="MultiQC v1.11" \
+      maintainer="dbrawand@nhs.net"
+
+RUN git clone https://github.com/ewels/MultiQC.git --branch v1.11 && \
+    cd MultiQC && \
+    git checkout  && \
+    python setup.py install
+
+RUN mkdir -p /data
+WORKDIR /data
+
+ENTRYPOINT [ "multiqc" ]
+CMD [ "." ]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# dnanexus_multiqc v 1.14.0
+# dnanexus_multiqc v1.14.0
 ewels/MultiQC [v1.11](https://github.com/ewels/MultiQC/)
 
 ## What does this app do?
-This app runs MultiQC to generate run wide quality control (QC) using the outputs from MokaAMP, MokaPipe and MokaWES pipelines including:
+This app runs MultiQC to generate run wide quality control (QC) using the outputs from MokaAMP, MokaPipe and MokaWES 
+pipelines including:
 * Picard (CalculateHsMetrics, MarkDuplicates and CollectMultipleMetrics, TargetedPcrMetrics)
 * FastQC 
 * bcl2fastq2
@@ -11,16 +12,20 @@ This app runs MultiQC to generate run wide quality control (QC) using the output
 * Sentieon (duplication_metrics)
 
 ## What are typical use cases for this app?
-To generate QC reports, this app should be run at the end of an NGS pipeline, when all QC software outputs are available.
+To generate QC reports, this app should be run at the end of an NGS pipeline, when all QC software outputs are 
+available.
 
 ## What data are required for this app to run?
 * project_for_multiQC - The name of the project to be assessed.
   * This project must have a 'QC' folder in its root directory.
-* coverage_level - Define which column to display from hsmetrics, reporting the percentage of target bases covered at the required depth (eg PCT_TARGET_BASES_20X)
+* coverage_level - Define which column to display from hsmetrics, reporting the percentage of target bases covered at 
+the required depth (eg PCT_TARGET_BASES_20X)
 
 Additional QC files are downloaded from other locations:
-* 'Stats.json' is downloaded from  /runfolder/Data/Intensities/BaseCalls/Stats if demultiplexing was performed by bcl2fastq v2.20 (or later) 
-* Any files with \*metrics\* in the name are downloaded. Sentieon apps output all files into the output folder, with inconsistent naming between apps. eg Duplication_metrics and duplication_metrics. 
+* 'Stats.json' is downloaded from  /runfolder/Data/Intensities/BaseCalls/Stats if demultiplexing was performed by 
+bcl2fastq v2.20 (or later) 
+* Any files with \*metrics\* in the name are downloaded. Sentieon apps output all files into the output folder, with 
+inconsistent naming between apps. eg Duplication_metrics and duplication_metrics. 
 
 ## What does this app output?
 The following outputs are placed in the DNAnexus project under '/QC/multiqc':
@@ -30,14 +35,27 @@ The following outputs are placed in the DNAnexus project under '/QC/multiqc':
 ## How does this app work?
 1. The app downloads all files within the QC/ directory of the project. 
 2. The dx_find_and_download function is used to search for specific files, which are downloaded only if found.
-3. If sention duplication_metrics files are present the app replaces the header (with a template packaged in the app) so the file is recognised as a picard markduplicates file.
-4. The app sets the minimum-fold coverage reported in the general stats table by editing 'dnanexus_multiqc_config.yaml'. This value comes from the app's 'coverage_level' input parameter.
-5. A dockerised version of MultiQC is used. The docker image is pulled each time the app is run.
+3. If sention duplication_metrics files are present the app replaces the header (with a template packaged in the app) 
+so the file is recognised as a picard markduplicates file.
+4. The app sets the minimum-fold coverage reported in the general stats table by editing 
+'dnanexus_multiqc_config.yaml'. This value comes from the app's 'coverage_level' input parameter.
+5. A dockerised version of MultiQC is used (v1.11). 
 6. MultiQC parses all files, including any recognised files in the report.
 7. The MultiQC outputs are uploaded to DNAnexus.
 
 ## What are the limitations of this app
 * The project which MultiQC is run on must be shared with the user mokaguys
-* Only one value can be given to the coverage_level parameter, which may not be ideal for runs with mixed samples. Multiple reports may be required in these cases
+* Only one value can be given to the coverage_level parameter, which may not be ideal for runs with mixed samples. 
+Multiple reports may be required in these cases
 
-## This app was made by Viapath Genome Informatics 
+## How was the .tar.gz file created?
+The multiqc docker image was created using the Dockerfile, tagged, and saved as a multiqc.tar.gz file which was placed 
+in the resources/usr/bin directory before building the dnanexus app. The app loads the docker images from the .tar.gz 
+files.
+```
+sudo docker build - < Dockerfile 
+sudo docker tag <image_id> ewels/multiqc:v1.11 
+sudo docker save ewels/multiqc:v1.11 | gzip > multiqc.tar.gz
+```
+
+## This app was made by Viapath Genome Informatics

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dnanexus_multiqc v 1.14.0
-ewels/MultiQC [v1.10.1](https://github.com/ewels/MultiQC/)
+ewels/MultiQC [v1.11](https://github.com/ewels/MultiQC/)
 
 ## What does this app do?
 This app runs MultiQC to generate run wide quality control (QC) using the outputs from MokaAMP, MokaPipe and MokaWES pipelines including:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dnanexus_multiqc v 1.13.0
+# dnanexus_multiqc v 1.14.0
 ewels/MultiQC [v1.10.1](https://github.com/ewels/MultiQC/)
 
 ## What does this app do?

--- a/dxapp.json
+++ b/dxapp.json
@@ -50,7 +50,7 @@
   "runSpec": {
     "interpreter": "bash",
     "distribution": "Ubuntu",
-    "release": "16.04",
+    "release": "20.04",
     "version": "0",
     "file": "src/code.sh"
   },

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,13 +1,13 @@
 {
-  "name": "multiqc_v1.13.0",
-  "title": "MultiQC_v1.13.0",
+  "name": "multiqc_v1.14.0",
+  "title": "MultiQC_v1.14.0",
   "summary": "v1.13.0 - Generates a run-wide QC report on various QC data files",
   "tags": [
     "Read QC",
     "Statistics"
   ],
   "properties": {
-    "github release": "v1.13.0"
+    "github release": "v1.14.0"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -51,6 +51,7 @@
     "interpreter": "bash",
     "distribution": "Ubuntu",
     "release": "16.04",
+    "version": "0",
     "file": "src/code.sh"
   },
   "access": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "multiqc_v1.14.0",
   "title": "MultiQC_v1.14.0",
-  "summary": "v1.13.0 - Generates a run-wide QC report on various QC data files",
+  "summary": "v1.14.0 - Generates a run-wide QC report on various QC data files",
   "tags": [
     "Read QC",
     "Statistics"

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "multiqc_v1.14.0",
   "title": "MultiQC_v1.14.0",
-  "summary": "v1.14.0 - Generates a run-wide QC report on various QC data files",
+  "summary": "v1.14.0 - Generates a run-wide QC report on various QC data files. The app runs dockerised MultiQC v1.11",
   "tags": [
     "Read QC",
     "Statistics"

--- a/resources/home/dnanexus/dnanexus_multiqc_config.yaml
+++ b/resources/home/dnanexus/dnanexus_multiqc_config.yaml
@@ -164,9 +164,8 @@ table_cond_formatting_rules:
 
 # Remove plots from HTML report
 remove_sections:
-    # For peddy, keep only the sex-check plot
+    # For peddy, keep only the sex-check plot and peddy-relatedness-plot
     - peddy-pca-plot
-    - peddy-relatedness-plot
     - peddy-hetcheck-plot
 
 #Modules to exclude

--- a/resources/home/dnanexus/dnanexus_multiqc_config.yaml
+++ b/resources/home/dnanexus/dnanexus_multiqc_config.yaml
@@ -40,11 +40,11 @@ extra_fn_clean_exts:
 #    - type: 'replace'
 #      pattern: 'NGS95a_'
     - type: remove
-      pattern: '_001'      
+      pattern: '_001'
     - type: remove
       pattern: '.markdup'
     - type: remove
-      pattern: '.duplication' 
+      pattern: '.duplication'
     - type: remove
       pattern: '.realigned'
     - type: remove
@@ -142,7 +142,6 @@ table_columns_visible:
         ancestry-prediction: False
         ancestry-prob_het_check: False
         predicted_sex_sex_check: False
-        predicted_sex_sex_check: False    
         sex_het_ratio: True
         sex_error: True
     verifyBAMID:
@@ -167,11 +166,6 @@ remove_sections:
     # For peddy, keep only the sex-check plot and peddy-relatedness-plot
     - peddy-pca-plot
     - peddy-hetcheck-plot
-
-#Modules to exclude
-exclude_modules:
-    #module breaks in newer MultiQC versions 
-    - gatk
 
 #Files to ignore
 fn_ignore_files:

--- a/src/code.sh
+++ b/src/code.sh
@@ -18,23 +18,27 @@ dx_find_and_download() {
     max_find=$3
 
     # Search input DNANexus project for files matching name string. Store to variable file_ids.
-    # `dx find data` returns a single space-delimited string. This result is warpped in parentheses creating a bash array.
+    # `dx find data` returns a single space-delimited string. This result is warpped in parentheses creating a bash
+    # #array.
     # Example with two matching files: echo ${file_ids[@]}
-    # > project-FP7Q76j07v81kb4564qPFyb1:file-FP96Pp80Vf2bB7ZqJBbzbvp5 project-FP7Q76j07v81kb4564qPFyb1:file-FP96Q3801p85KY2g7GPfP6J6
-    # $name in double quotes to ensure correct usage of wildcards passed into function eg ensure the string *metrics* is passed into dx find and not a list of files containing metrics in filename
-    file_ids=( $(dx find data --brief --path ${project}: --name "$name" --auth $API_KEY))
+    # > project-FP7Q76j07v81kb4564qPFyb1:file-FP96Pp80Vf2bB7ZqJBbzbvp5
+    # project-FP7Q76j07v81kb4564qPFyb1:file-FP96Q3801p85KY2g7GPfP6J6
+    # $name in double quotes to ensure correct usage of wildcards passed into function eg ensure the string *metrics*
+    # is passed into dx find and not a list of files containing metrics in filename
+    file_ids=( $(dx find data --brief --path "${project}": --name "$name" --auth "$API_KEY"))
 
     files_found=${#file_ids[@]} # ${#variable[@]} gives the number of elements in array $variable
 
     # Continue if no files found matching $name in $project
-    if [ $files_found -eq 0 ]; then
+    if [ "$files_found" -eq 0 ]; then
         echo "Nothing to download in $project matching $name."
     # Else if an integer was given as the max_find argument
     elif [[ $max_find =~ [0-9]+ ]]; then
         # Download if number of files found is less than or equal to the max argument
-        if [ $files_found -le $max_find ]; then
-            # as dx find is recursive -f any files which match this search term but were previously downloaded will be over written to prevent duplicate files.
-            dx download ${file_ids[@]} -f --auth $API_KEY
+        if [ "$files_found" -le "$max_find" ]; then
+            # as dx find is recursive -f any files which match this search term but were previously downloaded will be
+            # over written to prevent duplicate files.
+            dx download ${file_ids[@]} -f --auth "$API_KEY"
         # Else raise error
         else
             echo "Found $files_found files with name $name in $project. Expected $max_find files or less."
@@ -42,7 +46,7 @@ dx_find_and_download() {
         fi
     # Else download all files found using -f to overwrite duplicate files
     else
-        dx download ${file_ids[@]} -f --auth $API_KEY
+        dx download ${file_ids[@]} -f --auth "$API_KEY"
     fi
 }
 
@@ -51,72 +55,75 @@ set_general_stats_coverage() {
 
     # coverage_level is given as an input, store it in the config_cov variable.
     config_cov=$coverage_level
-	
+
     # Subsitute the default coverage in the config file for $config_cov
-    #   - 'n;' makes the substitution occur on the line after the first instance of "general_stats_target_coverage" 
+    #   - 'n;' makes the substitution occur on the line after the first instance of "general_stats_target_coverage"
 	sed -i "/general_stats_target_coverage/{n;s/30/${config_cov}/}" dnanexus_multiqc_config.yaml
 }
 
 main() {
     # SET VARIABLES
-    # Store the API key. Grants the script access to DNAnexus resources    
+    # Store the API key. Grants the script access to DNAnexus resources
     API_KEY=$(dx cat project-FQqXfYQ0Z0gqx7XG9Z2b4K43:mokaguys_nexus_auth_key)
     # Capture the project runfolder name. Names the multiqc HTML input and builds the output file path
-    project=$(echo $project_for_multiqc | sed 's/002_//')
+    # shellcheck disable=SC2001
+    project=$(echo "$project_for_multiqc" | sed 's/002_//')
     # Assign multiqc output directory name to variable and create
     outdir=out/multiqc/QC/multiqc && mkdir -p ${outdir}
     # Assing multiqc report output directory name to variable and create
     report_outdir=out/multiqc_report/QC/multiqc && mkdir -p ${report_outdir}
 
     # Files for multiqc are stored at 'project_for_multiqc:/QC/''. Download the contents of this folder.
-    dx download ${project_for_multiqc}:QC/* --auth ${API_KEY}
+    dx download "${project_for_multiqc}":QC/* --auth "${API_KEY}"
 
-    # Download all metrics files from the project (this will include the duplication metrics files (named slightly different by the various senteion apps))
-    dx_find_and_download '*metrics*' $project_for_multiqc 
+    # Download all metrics files from the project (this will include the duplication metrics files (named slightly
+    # different by the various senteion apps))
+    dx_find_and_download '*metrics*' "$project_for_multiqc"
 
-    
+
     # loop through all the duplication files to create a output.metrics file that MultiQC recognises
     # this uses a template header which replaces the existing header
     # NB the duplication metrics files are named as 'Duplication...' and 'duplication...'
     for file in ./*uplication_metrics*; do
         # if the file exists
-        if [ -e $file ]; then
+        if [ -e "$file" ]; then
             # create the output filename ending with *output.metrics (use i at end of regex to make case insensitive)
-            filename=$(echo $file | sed 's/duplication_/output./i' -)
+            filename=$(echo "$file" | sed 's/duplication_/output./i' -)
             # A template header is used - this contains a placeholder for the sample name
-            # To avoid too many rows in general stats table we want the samplename to be the same as that output from moka picard app (ending in _markdup and replacing any '.' with '_') 
-            samplename=$(echo $(basename $file) | sed 's/.Duplication_metrics.txt/_markdup/i' - )
-            samplename=$(echo $samplename | sed 's/\./_/' -)
+            # To avoid too many rows in general stats table we want the samplename to be the same as that output from
+            # moka picard app (ending in _markdup and replacing any '.' with '_')
+            samplename=$(echo $(basename "$file") | sed 's/.Duplication_metrics.txt/_markdup/i' - )
+            samplename=$(echo "$samplename" | sed 's/\./_/' -)
             # replace placeholder with the samplename and write header to output file
-            sed "s/placeholder/$samplename/" sention_output_metrics_header > $filename
-            # write all lines except the header line 
-            tail -n +2 $file >> $filename
+            sed "s/placeholder/$samplename/" sention_output_metrics_header > "$filename"
+            # write all lines except the header line
+            tail -n +2 "$file" >> "$filename"
         fi
         done
     # remove the template file so it doesn't appear on final report
     rm sention_output_metrics_header
 
     # Download bcl2fastq QC files if found in the project
-    dx_find_and_download 'Stats.json' $project_for_multiqc 1
+    dx_find_and_download 'Stats.json' "$project_for_multiqc" 1
 
     # Format dnanexus_multiqc_config.yaml file general stats coverage column based on project inputs
     set_general_stats_coverage
 
-    # Call multiqc v1.11 from docker image (ewels_multiqc_v1.11). This image is an asset on DNAnexus, bundled with the app.
+    # Load multiqc v1.11 image and call multiqc. This image is an asset on DNAnexus, bundled with the app.
     # MultiQC is run with the following parameters :
     #    multiqc <dir containing files> -n <path/to/output> -c </path/to/config>
     # The docker -v flag mounts a local directory to the docker environment in the format:
     #    -v local_dir:docker_dir
-    # Pull docker image from Dockerhub 
     # Multiqc searches for QC files. Docker passes any new files back to this mapped location on the DNAnexus worker.
-    docker pull ewels/multiqc:v1.11
-    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:v1.11 multiqc /home/dnanexus/ \
-        -n /home/dnanexus/${outdir}/${project}-multiqc.html -c /home/dnanexus/dnanexus_multiqc_config.yaml
+    docker load < /usr/bin/multiqc.tar.gz
+
+    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:v1.11 /home/dnanexus/ \
+        -n /home/dnanexus/${outdir}/"${project}"-multiqc.html -c /home/dnanexus/dnanexus_multiqc_config.yaml
 
     # Move the config file to the multiqc data output folder. This was created by running multiqc
-    mv dnanexus_multiqc_config.yaml ${outdir}/${project}-multiqc_data/
+    mv dnanexus_multiqc_config.yaml ${outdir}/"${project}"-multiqc_data/
     # Move the multiqc report HTML to the output directory for uploading to the Viapath server
-    mv ${outdir}/${project}-multiqc.html ${report_outdir}
+    mv ${outdir}/"${project}"-multiqc.html ${report_outdir}
 
     # Upload results
     dx-upload-all-outputs

--- a/src/code.sh
+++ b/src/code.sh
@@ -109,8 +109,8 @@ main() {
     #    -v local_dir:docker_dir
     # Pull docker image from Dockerhub 
     # Multiqc searches for QC files. Docker passes any new files back to this mapped location on the DNAnexus worker.
-    docker pull ewels/multiqc:1.11
-    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:1.11 multiqc /home/dnanexus/ \
+    docker pull ewels/multiqc:v1.11
+    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:v1.11 multiqc /home/dnanexus/ \
         -n /home/dnanexus/${outdir}/${project}-multiqc.html -c /home/dnanexus/dnanexus_multiqc_config.yaml
 
     # Move the config file to the multiqc data output folder. This was created by running multiqc

--- a/src/code.sh
+++ b/src/code.sh
@@ -102,15 +102,15 @@ main() {
     # Format dnanexus_multiqc_config.yaml file general stats coverage column based on project inputs
     set_general_stats_coverage
 
-    # Call multiqc v1.6 from docker image (ewels_multiqc_v1.6). This image is an asset on DNAnexus, bundled with the app.
+    # Call multiqc v1.11 from docker image (ewels_multiqc_v1.11). This image is an asset on DNAnexus, bundled with the app.
     # MultiQC is run with the following parameters :
     #    multiqc <dir containing files> -n <path/to/output> -c </path/to/config>
     # The docker -v flag mounts a local directory to the docker environment in the format:
     #    -v local_dir:docker_dir
     # Pull docker image from Dockerhub 
     # Multiqc searches for QC files. Docker passes any new files back to this mapped location on the DNAnexus worker.
-    docker pull ewels/multiqc:1.10.1
-    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:1.10.1 multiqc /home/dnanexus/ \
+    docker pull ewels/multiqc:1.11
+    docker run -v /home/dnanexus:/home/dnanexus ewels/multiqc:1.11 multiqc /home/dnanexus/ \
         -n /home/dnanexus/${outdir}/${project}-multiqc.html -c /home/dnanexus/dnanexus_multiqc_config.yaml
 
     # Move the config file to the multiqc data output folder. This was created by running multiqc


### PR DESCRIPTION
Version of multiqc updated to v1.11 from v1.10.1. App updated to display peddy relatedness plot on multiqc report, and removed exclusion of gatk from the report (this module no longer breaks multiqc). The app uses a tarred and zipped docker image rather than pulling the docker image when it runs - reduces the risk of the app failing due to any connectivity issues/issues with the repo. Also fixes the problems with using the official docker image (some modules in multiqc break when using the official docker image) - the image is built using a dockerfile in the repository. Execution environment updated to Ubuntu 20.04. 

Tested multiqc on a run from each run type below. Did this by copying the data into the testing project, deleting the existing multiqc output folder, then running multiqc. In turn for each of the runs. For all of the runs the output files were the same but with the new illumina lane metrics plots and peddy relatedness plots for runfolders where that tool's data is present.

- custom panels (002_210910_NB551068_0407_AH5FYTAFX3_NGS430)
- Onc (002_210915_M02631_0214_000000000-JVWDD_ONC21093)
- WES (002_210813_A01229_0032_AHGYK3DRXY_NGS423B_WES73SKIN)
- SNP (002_210915_NB551068_0408_AH5H3LAFX3_SNP021_SNP019_SNP020

Also tested on one run containing a contaminated sample to check that it could correctly identify this sample, which it could: 002_210621_A01229_0025_BHGGLCDRXY_NGS412B_WES71SKIN

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_multiqc/40)
<!-- Reviewable:end -->
